### PR TITLE
Specify minimum ruby version in gemspec

### DIFF
--- a/populate-env.gemspec
+++ b/populate-env.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '~> 2.3'
+
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
2.3.0 or greater is required for the use of the squiggly HEREDOC
in the CLI banner.