### PR TITLE
Set a conservative umask when writing .env

### DIFF
--- a/lib/populate_env/heroku/compilation.rb
+++ b/lib/populate_env/heroku/compilation.rb
@@ -31,7 +31,11 @@ module PopulateEnv
       end
       
       def perform
+        old_umask = File.umask
+        subtract_group_and_other_rwx=077
+        File.umask(subtract_group_and_other_rwx)
         options.destination.write(content)
+        File.umask(old_umask)
       end
     end
   end


### PR DESCRIPTION
Should set the file mode to 600 in most situations