### PR TITLE
Add --export flag to heroku command

### DIFF
--- a/lib/populate_env/cli/heroku_options.rb
+++ b/lib/populate_env/cli/heroku_options.rb
@@ -57,6 +57,11 @@ module PopulateEnv
           options.prompt_missing = value
         end
 
+        description = "Prefix variable declarations in output with export (defaults to #{options.skip_local_env})"
+        parser.on("--[no-]export", description) do |value|
+          options.export = value
+        end
+
         parser.parse!(argv)
 
         options

--- a/lib/populate_env/formatters/env_shell_section.rb
+++ b/lib/populate_env/formatters/env_shell_section.rb
@@ -1,10 +1,15 @@
 module PopulateEnv
   module Formatters
     class EnvShellSection
-      attr_reader :attribute
+      attr_reader :attribute, :export
 
-      def initialize(attribute)
+      def initialize(attribute, export: false)
         @attribute = attribute
+        @export = export
+      end
+
+      def prefix
+        export ? "export " : ""
       end
 
       def to_s
@@ -20,7 +25,7 @@ module PopulateEnv
           output << "# "
         end
         
-        output << "#{attribute.name}=#{attribute.value}\n"
+        output << "#{prefix}#{attribute.name}=#{attribute.value}\n"
       end
     end
   end

--- a/lib/populate_env/heroku/compilation.rb
+++ b/lib/populate_env/heroku/compilation.rb
@@ -22,7 +22,7 @@ module PopulateEnv
       def sections
         attribute_definitions.map do |definition|
           attribute = AttributeCompilation.new(definition, options, remote_config).perform
-          Formatters::EnvShellSection.new(attribute) if attribute
+          Formatters::EnvShellSection.new(attribute, export: options.export) if attribute
         end
       end
 

--- a/lib/populate_env/heroku/options.rb
+++ b/lib/populate_env/heroku/options.rb
@@ -14,6 +14,7 @@ module PopulateEnv
         heroku_remote: nil,
         skip_local_env: false,
         prompt_missing: true,
+        export: false,
         output: $stdout,
         input: $stdin,
         local_env: ENV


### PR DESCRIPTION
Dotenv support variable declarations in the form:

    export FOO=bar

So the resulting .env can be sourced into a users shell.  This adds a
--export flag to prefix the variable declarations in the .env file with
`export`, defaulting to false.