### PR TITLE
Make skip_local_env default to true

### DIFF
--- a/lib/populate_env/heroku/attribute_compilation.rb
+++ b/lib/populate_env/heroku/attribute_compilation.rb
@@ -24,7 +24,7 @@ module PopulateEnv
       private
 
       def attempt_to_populate_value
-        if !options.skip_local_env && options.local_env[definition.name]
+        if options.skip_local_env && options.local_env[definition.name]
           skip_due_to_local_env_var
           return
         end

--- a/lib/populate_env/heroku/options.rb
+++ b/lib/populate_env/heroku/options.rb
@@ -12,7 +12,7 @@ module PopulateEnv
         use_heroku_config: true,
         heroku_app: nil,
         heroku_remote: nil,
-        skip_local_env: false,
+        skip_local_env: true,
         prompt_missing: true,
         output: $stdout,
         input: $stdin,


### PR DESCRIPTION
CLI flags say this defaults to false, and it's value does, but the code
treats the flag as if it is defaulted to true based on the flag
description.

This changes the flag default to true and fixes the code accordingly.